### PR TITLE
Enhancements on componentWillReceiveProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,7 @@ var Pdf = React.createClass({
     if ((newProps.file && newProps.file !== this.props.file) || (newProps.content && newProps.content !== this.props.content)) {
       this.setState({page: null});
       this._loadPDFDocument(newProps);
-    }
-    if (!!this.state.pdf && !!newProps.page && newProps.page !== this.props.page) {
+    } else if (!!this.state.pdf && !!newProps.page && newProps.page !== this.props.page) {
       this.setState({page: null});
       this.state.pdf.getPage(newProps.page).then(this._onPageComplete);
     }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,10 @@ var ReactDOM = require('react-dom');
 var Pdf = React.createClass({
   displayName: 'React-PDF',
   propTypes: {
-    file: React.PropTypes.string,
+    file: React.PropTypes.oneOfType([
+      React.PropTypes.file,
+      React.PropTypes.string
+    ]),
     content: React.PropTypes.string,
     page: React.PropTypes.number,
     scale: React.PropTypes.number,
@@ -51,6 +54,7 @@ var Pdf = React.createClass({
   },
   componentWillReceiveProps: function(newProps) {
     if ((newProps.file && newProps.file !== this.props.file) || (newProps.content && newProps.content !== this.props.content)) {
+      this.setState({page: null});
       this._loadPDFDocument(newProps);
     }
     if (!!this.state.pdf && !!newProps.page && newProps.page !== this.props.page) {


### PR DESCRIPTION
Hello, during my need to implement a PDF viewer using react.js I came across react-pdf. Found it pretty handy and convenient so the only logical think to do was npm install... However during my use case I found two problems (one small and one that I consider not that small) that I have corrected in this fork that I open a pull request from. Here I will try to explain my use case and what is the motivation behind the code that I changed:

I. My use case - I find it pretty standard one. I want to write a stateful component that renders react-pdf's pdf component along with an input of file type that can select file and change the file that react-pdf shows. There are also some arrow for previous/next functionality, etc.

II. The problem that I experienced is that when the document is changed several pages are being rendered in the pdf.js's canvas and the page view is being corrupted. With some investigation I found out what causes this and fixed it. The other minor problem that I found out is that react-pdf's pdf component declare it's file property as "string", even though both string an file are supported. Due to that when a file is feeded, a warning message appear in the browser console, claiming that we misused the component.

III. The arguments behind my changes:
    \* changing file property propType -> React supports oneOfType composite propType, we can use it to properly validate the correctness of the passed file - https://facebook.github.io/react/docs/reusable-components.html.
    \* To explain the problem with componentWillReceiveProps method, lets focus on the code before my modifications while looking in the code in the render method that setTimeout to render a page. Now assume that we have the following case:
        - A pdf component is being rendered with file and page property.
        - With some user interaction we changed the page several time, therefor we have passed new page property to PDF component and invoked componentWillReceiveProps, that triggers the second "if" statement that reloads a page. So far so good.
        - Now by some user interaction we change the file that PDF component visualize. It is necessary to also specify the page of the new document that we want to see, since the index of the last page that was rendered can be missing in the new file. So we will change both file and page. Therefor we will invoke componentWillReceiveProps and will satisfy both "if" statement conditions. Here comes the tricky part. Since what happens in _loadPDFDocument and _onPageComplete is async and both methods setState they will both invoke re-render. Also the statement that nullifies the page will invoke another render. Now lets take a look what will happen in render:
            1. since setting page: null is not in promise it will invoke the first re-render, while page is null, hence the "self.state.page.render(renderContext);" statement in render will not be invoked. 
            2. when document is loaded _loadByteArray will be triggered (since we pass a file, not a string, this type is irrelevant) and will set the new file in state and will trigger page complete for the first time. The render triggered will not have page in state, since the page load that was invoked by onDocumentComplete is also a promise and is not resolved yet.
            3. Then the new document page will load for the first time. Lets assume that is the load requested by onDocumentComplete. That will set the page in the PDF component state and will re-render and this time will invoke self.state.page.render(renderContext); which will render a pdf page on our scree.
           4. Here comes the problem part - The page will be loaded again, because the second "if" statement "(!!this.state.pdf && !!newProps.page && newProps.page !== this.props.page)"  in componentWillReceiveProps will also be satisfied. !!this.state.pdf will be true, it will either be the old pdf or the new one, in newProps we will have the new document page that we desire, and it is very very likely that the newProps.page !== this.props.page. And now we will invoke another onPageComplete, with either the old pdf file or the new one, depending on if the promise that we previously triggered in the first "if" statement was resolved or no. And there is no logical motivation behind that in my opinion. When we change the file that we visualize we do not want to render several pages, we want to render only one page and only once and that is the page that we specified in the newProps.

IV. How my code fixes that:
    \* if we receive new file from props, we will reload the while PDF file and we expect that if the user wants to change the page, he also did so. In that case we do not care if the page was changed or not.
    \* If the pdf was not changed, but the page was changed, we want to load new page.
