### PR TITLE
Add prop-types peer dependency to remove deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "react": ">=15.0",
     "react-dom": ">=15.0"
   },
+  "peerDependencies": {
+    "prop-types": ">=15.0.0"
+  },
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.23.0",

--- a/src/react-pdf.jsx
+++ b/src/react-pdf.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 require('pdfjs-dist/web/compatibility');
 require('pdfjs-dist/build/pdf');


### PR DESCRIPTION
This change removes deprecation warnings when running in a non-production environment with React 15.5